### PR TITLE
fix: docker path for nitro-testnode_da_1

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -284,7 +284,7 @@ if $force_init; then
     echo == Bringing up Celestia Devnet
     docker-compose up -d da
     wait_up http://localhost:26659/header/1
-    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec nitro-testnode-da-1 celestia bridge auth admin --node.store  ${NODE_PATH})"
+    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec nitro-testnode_da_1 celestia bridge auth admin --node.store  ${NODE_PATH})"
 
     echo == Generating l1 keys
     docker-compose run scripts write-accounts


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This resolves an issue with missing permissions, due to incorrect path for the docker container from where the permissions are being set.

[Logs from a successful run](https://app.warp.dev/block/UDbqx5IZyKul7GIDyTc0at)
[Proof that other containers are named the same way
](https://gist.github.com/jcstein/cbaa1ce8bf1517901fc4da2b8b097465)
Other instances of "container not found", that may need to be looked into are:

```bash
== Deploying token bridge
Creating nitro-testnode_tokenbridge_run ... done
yarn run v1.22.19
$ ts-node ./scripts/genNetwork.ts
Error: No such container: nitro_sequencer_1
Error: No such container: nitro-sequencer-1
Error: No such container: nitro-testnode-sequencer-1
```

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
