### PR TITLE
fix: give container name to resolve discrepancies between different docker builds

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   da:
+    container_name: 'celestia-da'
     platform: linux/x86_64
     image: "ghcr.io/rollkit/local-celestia-devnet:v0.12.1"
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   da:
-    container_name: 'celestia-da'
+    container_name: 'da-celestia'
     platform: linux/x86_64
     image: "ghcr.io/rollkit/local-celestia-devnet:v0.12.1"
     ports:

--- a/test-node.bash
+++ b/test-node.bash
@@ -284,7 +284,7 @@ if $force_init; then
     echo == Bringing up Celestia Devnet
     docker-compose up -d da
     wait_up http://localhost:26659/header/1
-    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec celestia-da celestia bridge auth admin --node.store  ${NODE_PATH})"
+    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec da-celestia celestia bridge auth admin --node.store  ${NODE_PATH})"
 
     echo == Generating l1 keys
     docker-compose run scripts write-accounts

--- a/test-node.bash
+++ b/test-node.bash
@@ -284,7 +284,7 @@ if $force_init; then
     echo == Bringing up Celestia Devnet
     docker-compose up -d da
     wait_up http://localhost:26659/header/1
-    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec nitro-testnode_da_1 celestia bridge auth admin --node.store  ${NODE_PATH})"
+    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec celestia-da celestia bridge auth admin --node.store  ${NODE_PATH})"
 
     echo == Generating l1 keys
     docker-compose run scripts write-accounts


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Pairs with https://github.com/celestiaorg/nitro/pull/3
PR #4 changed the name of the path in the auth token setting of `test-node.bash`, but it is not standard across different operating systems.

## Problem

Example on macOS when container is named `nitro-testnode-da-1 `:

```bash
✔ Container nitro-testnode-da-1              Started                   0.6s
Waiting for http://localhost:26659/header/1 to come up..........................................................................Done!
Error response from daemon: No such container: nitro-testnode_da_1
```

Example on Ubuntu when container is named `nitro-testnode_da_1 `:
```bash
✔ Container nitro-testnode_da_1              Started                   0.6s
Waiting for http://localhost:26659/header/1 to come up..........................................................................Done!
Error response from daemon: No such container: nitro-testnode-da-1
```

## Solution

Give the container a name: `da-celestia`, keeping things standard across different OS.

```bash
 ✔ Container da-celestia                      Started                   0.1s
Waiting for http://localhost:26659/header/1 to come up...........................................................Done!
== Generating l1 keys
```

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
