### PR TITLE
feat: update sleep and container name to work on both Mac and Linux

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   da:
+    container_name: da-celestia
     platform: linux/x86_64
     image: "celestia-local-devnet:latest"
     ports:

--- a/test-node.bash
+++ b/test-node.bash
@@ -286,7 +286,7 @@ if $force_init; then
     echo == Bringing up Celestia Devnet
     docker-compose up -d da
     wait_up http://localhost:26659/header/1
-    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec nitro-testnode_da_1 celestia bridge auth admin --node.store  ${NODE_PATH})"
+    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec da-celestia celestia bridge auth admin --node.store  ${NODE_PATH})"
 
 
     echo == Generating l1 keys
@@ -334,7 +334,7 @@ if $force_init; then
     echo == Bringing up Celestia Devnet
     docker-compose up -d da
     wait_up http://localhost:26659/header/1
-    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec nitro-testnode-da-1 celestia bridge auth admin --node.store  ${NODE_PATH})"
+    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec da-celestia celestia bridge auth admin --node.store  ${NODE_PATH})"
 
     echo == Bringing up Blobstream Orchestrator
     docker-compose up -d orchestrator

--- a/test-node.bash
+++ b/test-node.bash
@@ -340,16 +340,16 @@ if $force_init; then
     docker-compose up -d orchestrator
 
     echo "Waiting for Blobstream Contracts"
-    sleep 100s
+    sleep 100
     echo == Bringing up Blobstream Relayer
     docker-compose up -d relayer
-    sleep 30s
+    sleep 30
 
     echo == Writing l2 chain config
     docker-compose run scripts write-l2-chain-config
 
     # Wait for Relayer to have deployed the contract
-    sleep 10s
+    sleep 10
     echo == Deploying L2
     sequenceraddress=`docker-compose run scripts print-address --account sequencer | tail -n 1 | tr -d '\r\n'`
     export BLOBSTREAM_ADDRESS="$(docker exec relayer cat ${BLOBSTREAM_PATH})"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Replaces #5 

## Problem 1

Example on macOS when container is named `nitro-testnode-da-1 `:

```bash
✔ Container nitro-testnode-da-1              Started                   0.6s
Waiting for http://localhost:26659/header/1 to come up..........................................................................Done!
Error response from daemon: No such container: nitro-testnode_da_1
```

Example on Ubuntu when container is named `nitro-testnode_da_1 `:
```bash
✔ Container nitro-testnode_da_1              Started                   0.6s
Waiting for http://localhost:26659/header/1 to come up..........................................................................Done!
Error response from daemon: No such container: nitro-testnode-da-1
```

## Solution 1

Give the container a name: `da-celestia`, keeping things standard across different OS.

```bash
 ✔ Container da-celestia                      Started                   0.1s
Waiting for http://localhost:26659/header/1 to come up...........................................................Done!
== Generating l1 keys
```
https://github.com/celestiaorg/nitro-testnode/pull/10/commits/4763e342a169ca9cff826752d3a0ef68ff67fc34

## Problem 2

Using `sleep 100s` on Mac does not run the same way as ubuntu, also, the docker file has 2 different syntax for 2 different sleep commands, with and without the `s`.

https://github.com/celestiaorg/nitro-testnode/blob/d5635fba3499adcd5713a19ecfd2c6ea19f8c0e6/test-node.bash#L262
https://github.com/celestiaorg/nitro-testnode/blob/d5635fba3499adcd5713a19ecfd2c6ea19f8c0e6/test-node.bash#L343

## Solution 2

Use standard `sleep x` from the original script, without the `s`, allowing this to run on all machines.

https://github.com/celestiaorg/nitro-testnode/pull/10/commits/1d53c496d6a2a38522ba1b1bad1f19671d39007e

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
