### PR TITLE
Add succinctx to gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "blockscout"]
 	path = blockscout
         url = https://github.com/OffchainLabs/blockscout.git
+[submodule "succinctx"]
+        path = succinctx
+        url = https://github.com/succinctlabs/succinctx.git


### PR DESCRIPTION
`git submodule update --init --recursive` on the Celestia nitro repo for the v2.2.2 blobstream branch is broken bc this gitmodule isn't declared
